### PR TITLE
Add to documentation and Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ tv-serial
 
 # Protobuf files
 *.pb-c.*
+
+# Build directory
+build/

--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,25 @@ OBJS = \
   $(BUILDDIR)/serial-commands.o \
   $(BUILDDIR)/tv-serial.o \
 
-$(BUILDDIR)/%.o: %.c $(DEPS)
+all: tv-serial tv-client.py 
+
+clean:
+	rm -rf $(BUILDDIR)
+
+$(BUILDDIR):
+	mkdir $(BUILDDIR)
+
+$(BUILDDIR)/%.o: %.c $(DEPS) $(BUILDDIR)
 	$(CC) -c -o $@ $< $(CFLAGS)
 
 tv-serial: $(OBJS)
 	$(CC) -o $@ $^ $(CFLAGS) $(LIBS)
 
-$(BUILDDIR)/commands.pb-c.c $(BUILDDIR)/commands.pb-c.h: commands.proto
+$(BUILDDIR)/commands.pb-c.c $(BUILDDIR)/commands.pb-c.h: commands.proto $(BUILDDIR)
 	protoc-c --c_out=$(BUILDDIR) $<
+
+tv-client.py: $(BUILDDIR)/commands_pb2.py
+
+$(BUILDDIR)/commands_pb2.py: commands.proto $(BUILDDIR)
+	touch $(BUILDDIR)/__init__.py
+	protoc --python_out=$(BUILDDIR) $<

--- a/README.md
+++ b/README.md
@@ -9,6 +9,31 @@ reference to using the serial port as an "external control device". Everything
 the remote control can do can be done via the serial port, which opens up some
 interesting automation possibilities.
 
+## C Dependencies
+
+You need ZeroMQ libs, the Protobuf C compiler, and Python dev files to compile the tv-serial executable
+```
+apt install libzmq3-dev protobuf-c-compiler python-dev
+```
+
+## Python Dependencies
+
+You need the python ZeroMQ and the Protobuf python library and compiler to run the tv-client.py script
+
+```
+apt install protobuf-compiler
+pip install pyzmq
+pip install protobuf
+```
+
+## Building
+
+Assuming you have all dependencies installed, it should be as easy as:
+
+```
+make
+``` 
+
 ## License
 
 ![AGPL v3.0](https://www.gnu.org/graphics/agplv3-88x31.png)

--- a/tv-client.py
+++ b/tv-client.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import argparse
-import commands_pb2
+from build import commands_pb2
 import sys
 import zmq
 


### PR DESCRIPTION
The readme didn't describe some of the dependencies that are necessary
to compile the C part, and run the Python part. Also, the steps for
getting the protobuf file generated for Python was not documented or
automated. Also, there was no simple way to clean up the generated
files. All of this is now fixed.